### PR TITLE
Inject namespace label in dev console queries for Loki

### DIFF
--- a/pkg/handler/topology.go
+++ b/pkg/handler/topology.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netobserv/network-observability-console-plugin/pkg/loki"
 	"github.com/netobserv/network-observability-console-plugin/pkg/metrics"
 	"github.com/netobserv/network-observability-console-plugin/pkg/model"
+	"github.com/netobserv/network-observability-console-plugin/pkg/model/fields"
 	"github.com/netobserv/network-observability-console-plugin/pkg/model/filters"
 	"github.com/netobserv/network-observability-console-plugin/pkg/prometheus"
 	"github.com/netobserv/network-observability-console-plugin/pkg/utils/constants"
@@ -126,17 +127,18 @@ func (h *Handlers) extractTopologyQueryParams(params url.Values, ds constants.Da
 	in.Groups = params.Get(groupsKey)
 	namespace := params.Get(namespaceKey)
 	rawFilters := params.Get(filtersKey)
-	filterGroups, err := filters.Parse(rawFilters, namespace)
+	filterGroups, err := filters.Parse(rawFilters)
 	if err != nil {
 		return nil, nil, qr, reqLimit, err
 	}
 
 	if shouldMergeReporters(in.DataField) {
-		filterGroups = expandReportersMergeQueries(
+		filterGroups = expandQueries(
 			filterGroups,
+			namespace,
 			func(filters filters.SingleQuery) bool {
 				// Do not expand if this is managed from prometheus
-				sr, _ := getEligiblePromMetric(h.PromInventory, filters, &in)
+				sr, _ := getEligiblePromMetric(h.PromInventory, filters, &in, namespace != "")
 				return sr != nil && len(sr.Found) > 0
 			},
 		)
@@ -164,7 +166,7 @@ func (h *Handlers) getTopologyFlows(ctx context.Context, cl clients, params url.
 		var lokiQ []string
 		var promQ []*prometheus.Query
 		for _, filters := range filterGroups {
-			lq, pq, code, err := buildTopologyQuery(h.Cfg, h.PromInventory, filters, in, &qr)
+			lq, pq, code, err := buildTopologyQuery(h.Cfg, h.PromInventory, filters, in, &qr, isDev)
 			if err != nil {
 				return nil, code, errors.New("Can't build query: " + err.Error())
 			}
@@ -186,7 +188,7 @@ func (h *Handlers) getTopologyFlows(ctx context.Context, cl clients, params url.
 		if len(filterGroups) > 0 {
 			filters = filterGroups[0]
 		}
-		lokiQ, promQ, code, err := buildTopologyQuery(h.Cfg, h.PromInventory, filters, in, &qr)
+		lokiQ, promQ, code, err := buildTopologyQuery(h.Cfg, h.PromInventory, filters, in, &qr, isDev)
 		if err != nil {
 			return nil, code, err
 		}
@@ -218,23 +220,51 @@ func shouldMergeReporters(metricType string) bool {
 	return metricType == constants.MetricTypeBytes || metricType == constants.MetricTypePackets
 }
 
-func expandReportersMergeQueries(queries filters.MultiQueries, isForProm func(filters filters.SingleQuery) bool) filters.MultiQueries {
-	var out filters.MultiQueries
-	for _, q := range queries {
-		// Do not expand if this is managed from prometheus
-		if isForProm(q) {
-			out = append(out, q)
-			continue
-		}
-		q1, q2 := filters.SplitForReportersMerge(q)
-		if q1 != nil {
-			out = append(out, q1)
-		}
-		if q2 != nil {
-			out = append(out, q2)
-		}
+func expandQueries(queries filters.MultiQueries, namespace string, isForProm func(filters filters.SingleQuery) bool) filters.MultiQueries {
+	// First, expand for reporter merge:
+
+	// The rationale here is that most traffic is duplicated from ingress and egress PoV, except cluster-external traffic.
+	// Ingress traffic will also contains pktDrop and DNS responses.
+	// Merging is done by running a first query with FlowDirection=INGRESS and another with FlowDirection=EGRESS AND DstOwnerName is empty,
+	// which stands for cluster-external.
+	// (Note that we use DstOwnerName both as an optimization as it's a Loki index,
+	// and as convenience because looking for empty fields won't work if they aren't indexed)
+	q1 := filters.SingleQuery{
+		filters.NewMatch(fields.FlowDirection, `"`+string(constants.Ingress)+`","`+string(constants.Inner)+`"`),
 	}
-	return out
+	q2 := filters.SingleQuery{
+		filters.NewMatch(fields.FlowDirection, `"`+string(constants.Egress)+`"`),
+		filters.NewMatch(fields.DstOwnerName, `""`),
+	}
+
+	shouldSkip := func(q filters.SingleQuery) bool {
+		if isForProm(q) {
+			return true
+		}
+		// If FlowDirection is enforced, skip merging both reporters
+		for _, m := range q {
+			if m.Key == fields.FlowDirection {
+				return true
+			}
+		}
+		return false
+	}
+
+	expanded := queries.Distribute([]filters.SingleQuery{q1, q2}, shouldSkip)
+
+	// Then, expand for namespace
+	if namespace != "" {
+		// TODO: this should actually be managed from the loki gateway, with "namespace" query param
+		expanded = expanded.Distribute(
+			[]filters.SingleQuery{
+				{filters.NewMatch(fields.SrcNamespace, `"`+namespace+`"`)},
+				{filters.NewMatch(fields.DstNamespace, `"`+namespace+`"`)},
+			},
+			isForProm,
+		)
+	}
+
+	return expanded
 }
 
 func buildTopologyQuery(
@@ -243,8 +273,9 @@ func buildTopologyQuery(
 	filters filters.SingleQuery,
 	in *loki.TopologyInput,
 	qr *v1.Range,
+	isDev bool,
 ) (string, *prometheus.Query, int, error) {
-	search, unsupportedReason := getEligiblePromMetric(promInventory, filters, in)
+	search, unsupportedReason := getEligiblePromMetric(promInventory, filters, in, isDev)
 	if unsupportedReason != "" {
 		hlog.Debugf("Unsupported Prometheus query; reason: %s.", unsupportedReason)
 	} else if search != nil && len(search.Found) > 0 {
@@ -289,7 +320,7 @@ func buildTopologyQuery(
 	return EncodeQuery(qb.Build()), nil, http.StatusOK, nil
 }
 
-func getEligiblePromMetric(promInventory *prometheus.Inventory, filters filters.SingleQuery, in *loki.TopologyInput) (*prometheus.SearchResult, string) {
+func getEligiblePromMetric(promInventory *prometheus.Inventory, filters filters.SingleQuery, in *loki.TopologyInput, isDev bool) (*prometheus.SearchResult, string) {
 	if in.DataSource != constants.DataSourceAuto && in.DataSource != constants.DataSourceProm {
 		return nil, ""
 	}
@@ -306,6 +337,9 @@ func getEligiblePromMetric(promInventory *prometheus.Inventory, filters filters.
 		return nil, unsupportedReason
 	}
 	labelsNeeded = append(labelsNeeded, fromFilters...)
+	if isDev {
+		labelsNeeded = append(labelsNeeded, fields.SrcNamespace)
+	}
 
 	// Search for such metric
 	r := promInventory.Search(labelsNeeded, in.DataField)

--- a/pkg/handler/topology_test.go
+++ b/pkg/handler/topology_test.go
@@ -1,0 +1,118 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/netobserv/network-observability-console-plugin/pkg/model/filters"
+	"github.com/netobserv/network-observability-console-plugin/pkg/utils/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitForReportersMerge_NoSplit(t *testing.T) {
+	mq := filters.MultiQueries{filters.SingleQuery{filters.NewMatch("srcns", "a"), filters.NewMatch("FlowDirection", string(constants.Ingress))}}
+	res := expandQueries(mq, "", func(filters.SingleQuery) bool { return false })
+	assert.Len(t, res, 1)
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("srcns", "a"),
+		filters.NewMatch("FlowDirection", string(constants.Ingress)),
+	}, res[0])
+}
+
+func TestSplitForReportersMerge(t *testing.T) {
+	mq := filters.MultiQueries{filters.SingleQuery{filters.NewMatch("srcns", "a"), filters.NewMatch("dstns", "b")}}
+	res := expandQueries(mq, "", func(filters.SingleQuery) bool { return false })
+
+	assert.Len(t, res, 2)
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("FlowDirection", `"`+string(constants.Ingress)+`","`+string(constants.Inner)+`"`),
+		filters.NewMatch("srcns", "a"),
+		filters.NewMatch("dstns", "b"),
+	}, res[0])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("FlowDirection", `"`+string(constants.Egress)+`"`),
+		filters.NewMatch("DstK8S_OwnerName", `""`),
+		filters.NewMatch("srcns", "a"),
+		filters.NewMatch("dstns", "b"),
+	}, res[1])
+}
+
+func TestExpand_ComplexQuery(t *testing.T) {
+	mq := filters.MultiQueries{
+		filters.SingleQuery{filters.NewMatch("key1", "a"), filters.NewMatch("FlowDirection", string(constants.Ingress))},
+		filters.SingleQuery{filters.NewMatch("key1", "a"), filters.NewMatch("key2", "b")},
+		filters.SingleQuery{filters.NewMatch("prom-handled", "a")},
+		filters.SingleQuery{filters.NewMatch("key1", "c"), filters.NewMatch("key2", "d")},
+	}
+	res := expandQueries(mq, "my-namespace", func(q filters.SingleQuery) bool { return q[0].Key == "prom-handled" })
+
+	assert.Len(t, res, 11)
+	// First is unchanged for reporters, because FlowDirection is forced, but namespaces are injected
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("SrcK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("key1", "a"),
+		filters.NewMatch("FlowDirection", string(constants.Ingress)),
+	}, res[0])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("DstK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("key1", "a"),
+		filters.NewMatch("FlowDirection", string(constants.Ingress)),
+	}, res[1])
+	// Second is expanded into 3rd+4th+5th+6th
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("SrcK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Ingress)+`","`+string(constants.Inner)+`"`),
+		filters.NewMatch("key1", "a"),
+		filters.NewMatch("key2", "b"),
+	}, res[2])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("DstK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Ingress)+`","`+string(constants.Inner)+`"`),
+		filters.NewMatch("key1", "a"),
+		filters.NewMatch("key2", "b"),
+	}, res[3])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("SrcK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Egress)+`"`),
+		filters.NewMatch("DstK8S_OwnerName", `""`),
+		filters.NewMatch("key1", "a"),
+		filters.NewMatch("key2", "b"),
+	}, res[4])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("DstK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Egress)+`"`),
+		filters.NewMatch("DstK8S_OwnerName", `""`),
+		filters.NewMatch("key1", "a"),
+		filters.NewMatch("key2", "b"),
+	}, res[5])
+	// Third is unchanged, because it's prom-handled
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("prom-handled", "a"),
+	}, res[6])
+	// Fourth is expanded into 8th+9th+10th+11th
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("SrcK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Ingress)+`","`+string(constants.Inner)+`"`),
+		filters.NewMatch("key1", "c"),
+		filters.NewMatch("key2", "d"),
+	}, res[7])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("DstK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Ingress)+`","`+string(constants.Inner)+`"`),
+		filters.NewMatch("key1", "c"),
+		filters.NewMatch("key2", "d"),
+	}, res[8])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("SrcK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Egress)+`"`),
+		filters.NewMatch("DstK8S_OwnerName", `""`),
+		filters.NewMatch("key1", "c"),
+		filters.NewMatch("key2", "d"),
+	}, res[9])
+	assert.Equal(t, filters.SingleQuery{
+		filters.NewMatch("DstK8S_Namespace", `"my-namespace"`),
+		filters.NewMatch("FlowDirection", `"`+string(constants.Egress)+`"`),
+		filters.NewMatch("DstK8S_OwnerName", `""`),
+		filters.NewMatch("key1", "c"),
+		filters.NewMatch("key2", "d"),
+	}, res[10])
+}

--- a/pkg/loki/flow_query.go
+++ b/pkg/loki/flow_query.go
@@ -108,10 +108,7 @@ func (q *FlowQueryBuilder) Filters(queryFilters filters.SingleQuery) error {
 }
 
 func (q *FlowQueryBuilder) addFilter(filter filters.Match) error {
-	// namespace filtering is managed by loki gateway so we can simply skip it
-	if filter.Key == "namespace" {
-		return nil
-	} else if !filterRegexpValidation.MatchString(filter.Values) {
+	if !filterRegexpValidation.MatchString(filter.Values) {
 		return fmt.Errorf("unauthorized sign in flows request: %s", filter.Values)
 	}
 

--- a/pkg/model/filters/logql.go
+++ b/pkg/model/filters/logql.go
@@ -221,6 +221,17 @@ func NewEmptyLineFilter(key string, not, moreThan, allowEmpty bool) LineFilter {
 	}
 }
 
+func ExactMatchLineFilter(key string, value string) LineFilter {
+	return LineFilter{
+		key:       key,
+		strictKey: true,
+		values: []lineMatch{{
+			valueType: typeString,
+			value:     value,
+		}},
+	}
+}
+
 func RegexMatchLineFilter(key string, strictKey bool, value string) LineFilter {
 	return LineFilter{
 		key:       key,

--- a/pkg/prometheus/inventory.go
+++ b/pkg/prometheus/inventory.go
@@ -116,11 +116,6 @@ func checkMatch(metric *config.MetricInfo, neededLabels []string, valueField str
 
 	var missingLabels []string
 	for _, neededLabel := range neededLabels {
-		// workaround to get namespaced metrics only for developer view
-		if neededLabel == "namespace" {
-			neededLabel = "SrcK8S_Namespace"
-		}
-
 		if !slices.Contains(metric.Labels, neededLabel) {
 			missingLabels = append(missingLabels, neededLabel)
 		}


### PR DESCRIPTION
Also, small refactoring / rationalization of the "expandReportersMergeQueries"/"SplitForReportersMerge" functions which are now "expandQueries" and "MultiQueries.Distribute", providing a more generic approach allowing to spread/distribute query parts across existing queries. This logic is reused to spread filters on src+dst namespaces across the input queries.